### PR TITLE
build(client): 🧑‍💻 add $components alias to sveltekit

### DIFF
--- a/client/svelte.config.js
+++ b/client/svelte.config.js
@@ -9,6 +9,9 @@ const config = {
 
   kit: {
     adapter: adapter(),
+    alias: {
+      $components: "./src/components",
+    },
   },
 };
 


### PR DESCRIPTION
this seams to be the standard place to keep components

this would allow us to have a component in `client/src/components/prompt.svelte` and import it from anywhere like `import Prompt from "$components/prompt.svelte";` instead of needing a bunch of `../../../..` everywhere