### PR TITLE
fix: 💚 use firebase token when running emulators as part f playwright test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,6 +144,8 @@ jobs:
 
       - name: Test
         run: npm --prefix client run test
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 
   deploy-staging:
     name: Deploy to Staging


### PR DESCRIPTION
I don't know why this is needed all of a sudden but it looks like firebase emulators crash without it