### PR TITLE
chore: 🧑‍💻 add warning for throwing literals

### DIFF
--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -21,5 +21,6 @@ module.exports = {
     "@typescript-eslint/no-inferrable-types": "off",
     "spaced-comment": "warn",
     "no-warning-comments": "warn",
+    "no-throw-literal": "warn",
   },
 };

--- a/functions/.eslintrc.js
+++ b/functions/.eslintrc.js
@@ -23,5 +23,6 @@ module.exports = {
   rules: {
     "spaced-comment": "warn",
     "no-warning-comments": "warn",
+    "no-throw-literal": "warn",
   },
 };


### PR DESCRIPTION
this is a bad practis because it means we don't get stack traces and eslint can help catch mistakes