### PR TITLE
fix(client): 🐛 Fix display name saving as "Default" 

### DIFF
--- a/client/src/lib/firebase/create-lobby.ts
+++ b/client/src/lib/firebase/create-lobby.ts
@@ -3,7 +3,7 @@ import { lobbyCollection } from "./firestore-collections";
 import { auth } from "./app";
 import { loginAnonymous } from "./auth";
 
-export async function createLobby(): Promise<string> {
+export async function createLobby(name: string): Promise<string> {
   let user = auth.currentUser?.uid;
 
   if (user == undefined) {
@@ -19,7 +19,7 @@ export async function createLobby(): Promise<string> {
           {
             alive: true,
             avatar: 1,
-            displayName: "default",
+            displayName: name,
           },
         ],
         state: "WAIT",

--- a/client/src/routes/+page.svelte
+++ b/client/src/routes/+page.svelte
@@ -37,7 +37,7 @@
     // Create User
     await saveOrCreate(user, userData, name);
     // Create Lobby
-    const code = await createLobby();
+    const code = await createLobby(name);
     // Go to game page
     goto("/game?code=" + code);
   };


### PR DESCRIPTION
Display name no longer saves as "Default" when creating a lobby. Whatever name entered will be saved instead