### PR TITLE
fix(client): 🐛 Display name is blank once user signs out

### DIFF
--- a/client/src/lib/firebase/auth.ts
+++ b/client/src/lib/firebase/auth.ts
@@ -35,5 +35,6 @@ export async function loginAnonymous() {
 }
 
 export function logOut() {
+  location.reload();
   return signOut(auth);
 }


### PR DESCRIPTION
Reload page on sign out function to clear display name once signed out.