### PR TITLE
feat(functions): ✨ Trim ending spaces off name, no error throw.

### DIFF
--- a/client/src/routes/+page.svelte
+++ b/client/src/routes/+page.svelte
@@ -13,7 +13,7 @@
 
   let name: string = "";
   let nameDirty: boolean = false;
-  $: nameValidation = displayNameValidator(name);
+  $: nameValidation = displayNameValidator(name.trim());
 
   let errorMessage: string = "";
 

--- a/client/src/routes/join/+page.svelte
+++ b/client/src/routes/join/+page.svelte
@@ -18,7 +18,7 @@
 
   let name: string = "";
   let nameDirty: boolean = false;
-  $: nameValidation = displayNameValidator(name);
+  $: nameValidation = displayNameValidator(name.trim());
 
   let code: string = "";
   let codeDirty: boolean = false;

--- a/functions/src/firestore-types/users.ts
+++ b/functions/src/firestore-types/users.ts
@@ -36,11 +36,6 @@ export type UserData = {
 };
 
 export function displayNameValidator(displayName: string): { valid: true } | { valid: false; reason: string } {
-  let newname = displayName;
-  while (newname.charAt(newname.length - 1) === " ") {
-    newname = newname.slice(0, -1);
-  }
-  displayName = newname;
   if (displayName === "") {
     return { valid: false, reason: "Display name must not be empty" };
   }
@@ -53,7 +48,7 @@ export function displayNameValidator(displayName: string): { valid: true } | { v
   }
 
   if (displayName !== displayName.trim()) {
-    return { valid: false, reason: "Display name must not contain leading whitespace" };
+    return { valid: false, reason: "Display name must not contain leading or trailing whitespace" };
   }
 
   if (displayName.search(/[^A-Za-z0-9-_ ]+/) >= 0) {

--- a/functions/src/firestore-types/users.ts
+++ b/functions/src/firestore-types/users.ts
@@ -36,6 +36,11 @@ export type UserData = {
 };
 
 export function displayNameValidator(displayName: string): { valid: true } | { valid: false; reason: string } {
+  let newname = displayName;
+  while (newname.charAt(newname.length - 1) === " ") {
+    newname = newname.slice(0, -1);
+  }
+  displayName = newname;
   if (displayName === "") {
     return { valid: false, reason: "Display name must not be empty" };
   }
@@ -48,7 +53,7 @@ export function displayNameValidator(displayName: string): { valid: true } | { v
   }
 
   if (displayName !== displayName.trim()) {
-    return { valid: false, reason: "Display name must not contain leading or trailing whitespace" };
+    return { valid: false, reason: "Display name must not contain leading whitespace" };
   }
 
   if (displayName.search(/[^A-Za-z0-9-_ ]+/) >= 0) {


### PR DESCRIPTION
Make it so that you may enter a name with spaces at the end. The code will trim it for you and won't throw an error. This works for both splash and join and does still trim all the ending spaces off.