### PR TITLE
fix: 🚑️ add index for alive lobby chat messages and display more messages

### DIFF
--- a/client/src/components/AccountButton.svelte
+++ b/client/src/components/AccountButton.svelte
@@ -21,6 +21,7 @@
   let errorMessage: string = "";
 
   function getErrorMsg(error: unknown): string {
+    console.error(error);
     let errorMsg = error instanceof Error ? error.message : String(error);
     switch (errorMsg) {
       case "Firebase: Error (auth/user-not-found).":

--- a/client/src/components/ChatRoom.svelte
+++ b/client/src/components/ChatRoom.svelte
@@ -97,7 +97,8 @@
       // if there's an error message then clear it
       errorMessage = "";
     } catch (err) {
-      // catch and display erro
+      // catch and display error
+      console.error(err);
       errorMessage = err instanceof Error ? err.message : String(err);
     }
   }

--- a/client/src/components/Lobby.svelte
+++ b/client/src/components/Lobby.svelte
@@ -51,6 +51,7 @@
       await changeAvatar({ lobbyCode, avatar });
       errorMessage = "";
     } catch (err) {
+      console.error(err);
       errorMessage = err instanceof Error ? err.message : String(err);
     }
   }
@@ -61,6 +62,7 @@
       await startGame({ code: lobbyCode });
     } catch (err) {
       waiting = false;
+      console.error(err);
       errorMessage = err instanceof Error ? err.message : String(err);
     }
   }
@@ -71,6 +73,7 @@
       await leaveLobby({ code: lobbyCode });
     } catch (err) {
       waiting = false;
+      console.error(err);
       errorMessage = err instanceof Error ? err.message : String(err);
     }
   }

--- a/client/src/components/LobbyChat.svelte
+++ b/client/src/components/LobbyChat.svelte
@@ -60,6 +60,7 @@
       errorMessage = "";
     } catch (err) {
       // catch and display error
+      console.error(err);
       errorMessage = err instanceof Error ? err.message : String(err);
     }
   }

--- a/client/src/components/LobbyChat.svelte
+++ b/client/src/components/LobbyChat.svelte
@@ -4,7 +4,7 @@
   import ChatMessages from "./ChatMessages.svelte";
   import IconButton from "@smui/icon-button";
   import { onDestroy } from "svelte";
-  import { onSnapshot, orderBy, query, where } from "firebase/firestore";
+  import { onSnapshot, orderBy, type Query, query, where } from "firebase/firestore";
   import type { LobbyChatMessage, Lobby } from "$lib/firebase/firestore-types/lobby";
   import type { Unsubscribe } from "firebase/auth";
   import { getLobbyChatCollection } from "$lib/firebase/firestore-collections";
@@ -23,7 +23,7 @@
 
   $: lobby, onLobbyChange();
   function onLobbyChange() {
-    let messageQuery;
+    let messageQuery: Query<LobbyChatMessage>;
     if (userInfo == undefined) {
       return;
     } else if (userInfo.alive) {
@@ -32,9 +32,16 @@
       messageQuery = query(getLobbyChatCollection(lobbyCode), orderBy("timestamp", "asc"));
     }
     unsubscribeChatMessages?.();
-    unsubscribeChatMessages = onSnapshot(messageQuery, (collection) => {
-      chatMessages = collection.docs.map((message) => message.data());
-    });
+    unsubscribeChatMessages = onSnapshot(
+      messageQuery,
+      (collection) => {
+        chatMessages = collection.docs.map((message) => message.data());
+      },
+      (err) => {
+        console.error(err);
+        errorMessage = err instanceof Error ? err.message : String(err);
+      }
+    );
   }
 
   onDestroy(() => {

--- a/client/src/components/LobbySettings.svelte
+++ b/client/src/components/LobbySettings.svelte
@@ -41,6 +41,7 @@
       });
       showLobbySettings = false;
     } catch (err) {
+      console.error(err);
       errorMessage = err instanceof Error ? err.message : String(err);
     }
   }

--- a/client/src/components/Prompt.svelte
+++ b/client/src/components/Prompt.svelte
@@ -43,6 +43,7 @@
       await setDoc(answerDoc, { answer });
       displayAnswer = answer;
     } catch (error) {
+      console.error(error);
       errorMessage = error instanceof Error ? error.message : String(error);
     }
   }

--- a/client/src/components/Stalker.svelte
+++ b/client/src/components/Stalker.svelte
@@ -30,6 +30,7 @@
     try {
       await stalkChatroom({ code: lobbyCode, chatId });
     } catch (err) {
+      console.error(err);
       errorMessage = err instanceof Error ? err.message : String(err);
     }
   }

--- a/client/src/components/Vote.svelte
+++ b/client/src/components/Vote.svelte
@@ -43,6 +43,7 @@
       await addVote(lobbyCode, $user?.uid ?? "", target);
       errorMessage = "";
     } catch (error) {
+      console.error(error);
       errorMessage = error instanceof Error ? error.message : String(error);
     }
   }

--- a/client/src/routes/+page.svelte
+++ b/client/src/routes/+page.svelte
@@ -62,6 +62,7 @@
       goto("/game?code=" + response.data.code);
     } catch (err) {
       waiting = false;
+      console.error(err);
       errorMessage = err instanceof Error ? err.message : String(err);
     }
   }
@@ -74,6 +75,7 @@
       goto("/join");
     } catch (err) {
       waiting = false;
+      console.error(err);
       errorMessage = err instanceof Error ? err.message : String(err);
     }
   }

--- a/client/src/routes/game/+page.svelte
+++ b/client/src/routes/game/+page.svelte
@@ -33,6 +33,8 @@
   $: countdownVisible = lobby != undefined && DISPLAY_TIMERS[lobby.state] == true;
   let timer: ReturnType<typeof setInterval>;
 
+  let errorMessage: string = "";
+
   function updateCountdown() {
     if (lobby == undefined) {
       throw new Error("attempted to update countdown when lobby is undefined");
@@ -76,20 +78,34 @@
     updateCountdown();
 
     // We want them to subscribe to the lobby on mount
-    unsubscribeLobby = onSnapshot(lobbyDocRef, (doc) => {
-      // will change lobby to the new doc data
-      lobby = doc.data();
-      clearInterval(timer);
-      if (lobby != undefined) {
-        timer = setInterval(updateCountdown, 500);
+    unsubscribeLobby = onSnapshot(
+      lobbyDocRef,
+      (doc) => {
+        // will change lobby to the new doc data
+        lobby = doc.data();
+        clearInterval(timer);
+        if (lobby != undefined) {
+          timer = setInterval(updateCountdown, 500);
+        }
+      },
+      (err) => {
+        console.error(err);
+        errorMessage = err instanceof Error ? err.message : String(err);
       }
-    });
+    );
 
     // We want them to subscribe to the privatePlayer on mount
-    unsubscribePrivatePlayer = onSnapshot(privatePlayerDocRef, (doc) => {
-      // will change privatePlayer to the new doc data
-      privatePlayer = doc.data();
-    });
+    unsubscribePrivatePlayer = onSnapshot(
+      privatePlayerDocRef,
+      (doc) => {
+        // will change privatePlayer to the new doc data
+        privatePlayer = doc.data();
+      },
+      (err) => {
+        console.error(err);
+        errorMessage = err instanceof Error ? err.message : String(err);
+      }
+    );
   });
 
   onDestroy(() => {
@@ -174,6 +190,9 @@
   {/if}
 
   <div class="scroll-container">
+    {#if errorMessage !== ""}
+      <p class="error">{errorMessage}</p>
+    {/if}
     {#if $user == null || lobby == undefined || lobbyCode == null || (countdown < 0 && countdownVisible)}
       <div class="spinner-wraper">
         <CircularProgress indeterminate />

--- a/client/src/routes/join/+page.svelte
+++ b/client/src/routes/join/+page.svelte
@@ -75,6 +75,7 @@
     } catch (err) {
       waiting = false;
       // if the lobby doesn't exist then error is thrown
+      console.error(err);
       errorMessage = err instanceof Error ? err.message : String(err);
       if (errorMessage == "You are already in the lobby!") {
         waiting = true;

--- a/client/src/routes/settings/+page.svelte
+++ b/client/src/routes/settings/+page.svelte
@@ -38,9 +38,16 @@
     unsubscribeUserData?.();
 
     // subscribe to new user doc
-    unsubscribeUserData = onSnapshot(userDataDocRef, (doc) => {
-      userData = doc.data();
-    });
+    unsubscribeUserData = onSnapshot(
+      userDataDocRef,
+      (doc) => {
+        userData = doc.data();
+      },
+      (err) => {
+        console.error(err);
+        preferenceErrorMessage = err instanceof Error ? err.message : String(err);
+      }
+    );
   }
 
   onDestroy(() => {

--- a/client/src/routes/settings/+page.svelte
+++ b/client/src/routes/settings/+page.svelte
@@ -44,8 +44,7 @@
         userData = doc.data();
       },
       (err) => {
-        console.error(err);
-        preferenceErrorMessage = err instanceof Error ? err.message : String(err);
+        preferenceErrorMessage = getErrorMsg(err);
       }
     );
   }
@@ -78,7 +77,7 @@
         await updateDoc(userDataDocRef, newPreferences);
       }
     } catch (error) {
-      preferenceErrorMessage = error instanceof Error ? error.message : String(error);
+      preferenceErrorMessage = getErrorMsg(error);
     }
   }
 
@@ -112,6 +111,7 @@
   let deleteErr = "";
 
   function getErrorMsg(error: unknown): string {
+    console.error(error);
     let errorMsg = error instanceof Error ? error.message : String(error);
     switch (errorMsg) {
       case "Firebase: Password should be at least 6 characters (auth/weak-password).":

--- a/client/src/routes/stats/+page.svelte
+++ b/client/src/routes/stats/+page.svelte
@@ -20,13 +20,22 @@
   let catRatio: number;
   let catfishRatio: number;
 
+  let errorMessage: string = "";
+
   onMount(() => {
     const userId = $page.url.searchParams.get("user");
 
     if (userId !== null) {
-      unsubscribeUser = onSnapshot(doc(userCollection, userId), (userDoc) => {
-        userInfo = userDoc.data();
-      });
+      unsubscribeUser = onSnapshot(
+        doc(userCollection, userId),
+        (userDoc) => {
+          userInfo = userDoc.data();
+        },
+        (err) => {
+          console.error(err);
+          errorMessage = err instanceof Error ? err.message : String(err);
+        }
+      );
     }
   });
 
@@ -47,6 +56,9 @@
 <Header />
 
 <main>
+  {#if errorMessage !== ""}
+    <p class="error">{errorMessage}</p>
+  {/if}
   {#if $user == null}
     <div class="spinner-wraper">
       <CircularProgress indeterminate />

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,13 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "chatMessages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "alive", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "ASCENDING" }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }


### PR DESCRIPTION
This PR fixes #203 by adding an index for sorting alive lobby messages by timestamp

This bug was hard to fix because the errors where not being displayed so this PR also displays error messages in cases similar to the one fixed by this PR