### PR TITLE
fix(client): 🐛 disable caching for non-immutable output

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -19,6 +19,15 @@
             "value": "public, max-age=31536000, immutable"
           }
         ]
+      },
+      {
+        "source": "/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, no-cache"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
in #244 we made static assets be cached forever now we make everything else be not cached at all

this solves a problem where production acts kinda weird for an hour after deploying

this solves a problem where the home page is sometimes displayed instead of the offline page