### PR TITLE
fix(client): 🐛 use correct order for headers

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -13,21 +13,11 @@
     "headers": [
       {
         "source": "/_app/immutable/**",
-        "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "public, max-age=31536000, immutable"
-          }
-        ]
+        "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
       },
       {
         "source": "/**",
-        "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "public, no-cache"
-          }
-        ]
+        "headers": [{ "key": "Cache-Control", "value": "public, no-cache" }]
       }
     ]
   },

--- a/firebase.json
+++ b/firebase.json
@@ -12,12 +12,12 @@
     "cleanUrls": true,
     "headers": [
       {
-        "source": "/_app/immutable/**",
-        "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
-      },
-      {
         "source": "/**",
         "headers": [{ "key": "Cache-Control", "value": "public, no-cache" }]
+      },
+      {
+        "source": "/_app/immutable/**",
+        "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
       }
     ]
   },


### PR DESCRIPTION
It looks like the order in firebase hosting headers matters so this PR changes the order and improves formatting